### PR TITLE
fix: fit border to embed links and quote casts

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -239,13 +239,6 @@
   bottom: -1px;
 }
 
-.farcaster-embed-url-link::before,
-.farcaster-embed-quote-cast::before {
-  width: calc(100% - 2px);
-  height: calc(100% - 2px);
-  z-index: 3;
-}
-
 .farcaster-embed-url-link:hover::before {
   opacity: 0.5;
 }


### PR DESCRIPTION
| Before | After |
|---|---|
| ![Capture-2024-10-02-122258](https://github.com/user-attachments/assets/167d446a-b84e-4fd4-988a-ed3f78c0ab23) | ![Capture-2024-10-02-122442](https://github.com/user-attachments/assets/b66a868c-4b2c-45a9-a527-e60469bd76b2) |