### PR TITLE
align Warpcast logo with stats, always display horizontally

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -266,31 +266,23 @@
 }
 
 .farcaster-embed-stats {
-  margin-top: 0.5rem !important;
+  margin-top: 1rem !important;
   margin-bottom: -0.375rem !important;
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   justify-content: space-between;
   container: stats / inline-size;
 }
 
 .farcaster-embed-stats ul {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 0.5rem 1.5rem;
+  display: flex;
+  gap: 1.5rem;
   list-style-type: none;
-  margin-top: 1rem !important;
 }
 
 @container stats (min-width: 340px) {
-  .farcaster-embed-stats {
-    align-items: center;
-  }
-
   .farcaster-embed-stats ul {
-    display: flex;
-    gap: 3rem;
-    margin-top: 0 !important;
+    gap: 2rem;
   }
 }
 
@@ -305,10 +297,6 @@
 
 .farcaster-embed-warpcast-icon {
   display: flex;
-  items-align: center;
-  position: relative;
-  bottom: -0.25rem;
-  right: -0.25rem;
 }
 
 .farcaster-embed-warpcast-link {


### PR DESCRIPTION
It bothers me that the Warpcast logo is slightly misaligned with the stats. Also, the stacked stats (2x2 grid) at smaller sizes looks a bit off to me and takes up more space. I think we can still display all of the stats inline by reducing the gap a bit at smaller sizes. Totally fine if you don't agree here (there's no "right" answer), feel free to close this if so.

| | Before | After |
|---|---|---|
| Larger | ![Capture-2024-10-02-125017](https://github.com/user-attachments/assets/c33410f8-6252-41d5-a3d9-981a35baf913) | ![Capture-2024-10-02-125620](https://github.com/user-attachments/assets/872f14bc-c867-4b08-840b-ebf8f2c844e6) |
| Smaller | ![Capture-2024-10-02-125049](https://github.com/user-attachments/assets/7be43f82-db6a-474e-b0b0-46ab3aa57c7d) | ![Capture-2024-10-02-125449](https://github.com/user-attachments/assets/cbc96062-1880-4ae0-a888-1f460c87ccb8) |