### PR TITLE
don't display watches (bookmarks)

### DIFF
--- a/src/components/cast.tsx
+++ b/src/components/cast.tsx
@@ -1,9 +1,9 @@
 import Linkify from "linkify-react";
-import { ReplyIcon, RecastIcon, LikeIcon, BookmarkIcon, WarpcastIcon } from "./icons";
+import type { FarcasterEmbedOptions } from "../options";
 import type { CastData } from "../types";
 import { CastImages } from "./cast-images";
 import { CastVideos } from "./cast-videos";
-import type { FarcasterEmbedOptions } from "../options";
+import { LikeIcon, RecastIcon, ReplyIcon, WarpcastIcon } from "./icons";
 
 const linkifyOptions = {
   className: "farcaster-embed-body-link",
@@ -58,7 +58,6 @@ export function CastEmbed({
   const replies = cast.replies && cast.replies.count;
   const likes = cast.reactions && cast.reactions.count;
   const recasts = cast.combinedRecastCount ? cast.combinedRecastCount : cast.recasts.count;
-  const watches = cast.watches && cast.watches.count;
   const images = cast.embeds && cast.embeds.images;
   const hasImages = images && images.length > 0;
   const hasVideos = cast.embeds && cast.embeds.videos && cast.embeds.videos.length > 0;
@@ -213,12 +212,6 @@ export function CastEmbed({
             <a className="farcaster-embed-stats-link" href={warpcastUrl} target="_blank">
               <LikeIcon />
               <span>{likes.toLocaleString("en-US")}</span>
-            </a>
-          </li>
-          <li>
-            <a className="farcaster-embed-stats-link" href={warpcastUrl} target="_blank">
-              <BookmarkIcon />
-              <span>{watches.toLocaleString("en-US")}</span>
             </a>
           </li>
         </ul>

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -48,22 +48,6 @@ export const LikeIcon = () => (
   </svg>
 );
 
-export const BookmarkIcon = () => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="16"
-    height="16"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"></path>
-  </svg>
-);
-
 export const WarpcastIcon = () => (
   <svg width="24" height="24" viewBox="0 0 1260 1260" fill="none" xmlns="http://www.w3.org/2000/svg">
     <g clipPath="url(#fc-embed-clip1)">


### PR DESCRIPTION
Reasoning behind this change:
1. The embed displays watches but uses a bookmark icon, which is misleading
2. Watches are no longer a feature in Warpcast
3. Bookmark counts aren't available via API and are Warpcast-only for now