### PR TITLE
feat: add support for optional logo link

### DIFF
--- a/src/components/cast.tsx
+++ b/src/components/cast.tsx
@@ -222,7 +222,7 @@ export function CastEmbed({
             </a>
           </li>
         </ul>
-        {options.displayLinkLogo && (
+        {!options.hideFarcasterLogo && (
           <div className="farcaster-embed-farcaster-icon">
             <a href={farcasterUrl} title="Show on Farcaster" target="_blank" className="farcaster-embed-farcaster-link">
               <FarcasterIcon />

--- a/src/components/cast.tsx
+++ b/src/components/cast.tsx
@@ -222,11 +222,13 @@ export function CastEmbed({
             </a>
           </li>
         </ul>
-        <div className="farcaster-embed-farcaster-icon">
-          <a href={farcasterUrl} title="Show on Farcaster" target="_blank" className="farcaster-embed-farcaster-link">
-            <FarcasterIcon />
-          </a>
-        </div>
+        {options.displayLinkLogo && (
+          <div className="farcaster-embed-farcaster-icon">
+            <a href={farcasterUrl} title="Show on Farcaster" target="_blank" className="farcaster-embed-farcaster-link">
+              <FarcasterIcon />
+            </a>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/options.ts
+++ b/src/options.ts
@@ -3,6 +3,7 @@ export type FarcasterEmbedOptions = {
   timestampLocale?: string;
   customEndpoint?: string;
   silentError?: boolean;
+  displayLinkLogo?: boolean;
 };
 
 export const defaultOptions: FarcasterEmbedOptions = {
@@ -13,4 +14,5 @@ export const defaultOptions: FarcasterEmbedOptions = {
   },
   timestampLocale: "en-US",
   silentError: false,
+  displayLinkLogo: true,
 };

--- a/src/options.ts
+++ b/src/options.ts
@@ -3,7 +3,7 @@ export type FarcasterEmbedOptions = {
   timestampLocale?: string;
   customEndpoint?: string;
   silentError?: boolean;
-  displayLinkLogo?: boolean;
+  hideFarcasterLogo?: boolean;
 };
 
 export const defaultOptions: FarcasterEmbedOptions = {
@@ -14,5 +14,5 @@ export const defaultOptions: FarcasterEmbedOptions = {
   },
   timestampLocale: "en-US",
   silentError: false,
-  displayLinkLogo: true,
+  hideFarcasterLogo: false,
 };


### PR DESCRIPTION
Support for optionally displaying the Farcaster logo.

Reasoning behind this is I am using this package in a miniapp, and this link opens in a web view.  I removed it in my local instance and made the entire cast window a button to call the FC SDK to open a cast, but figured others might want the same functionality.

@pugson If you don't think this works in the main repo, don't worry about it.  Or if you feel you want to keep the branding, but add support to optionally remove linking functionality, happy to make that change as well.